### PR TITLE
[REG-921] Bot QOL fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
 
   // Some abilities require an enemy/ally id and position
   const abilities = CharInfo.abilities[charType];
-  console.log(`Considering abilities JSON.stringify(abilities)`);
+  console.log(`Considering abilities ${JSON.stringify(abilities)}`);
   const abilityIndex = CURRENT_ABILITY % abilities.length;
   const ability = abilities[abilityIndex];
   console.log(`Trying out ability ${ability}`);

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class RGValidator {
 
 }
 
-let charType = Math.random() * 100 % 4;
+let charType = (Math.random() * 1000000) % 4;
 
 export function configureBot() {
   console.log(`Unity bot configureBot function called, charType: ${charType} !`)

--- a/index.js
+++ b/index.js
@@ -78,6 +78,12 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
 
   console.log(`Running 'runTurn' with playerId: ${playerId}, tickInfo: ${JSON.stringify(tickInfo)}`)
 
+  // select 2 abilities per tick
+  selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue);
+  selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue);
+}
+
+function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
   const myPlayer = BossRoomBot.getAlly(tickInfo, playerId);
   console.log(`My player is at position: ${JSON.stringify(myPlayer.position)}`)
 
@@ -88,33 +94,32 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
   const ability = abilities[abilityIndex];
   console.log(`Trying out ability ${ability}`);
   if (CharInfo.abilityTargets[charType][abilityIndex] == 1) {
-      const enemies = BossRoomBot.getEnemies(tickInfo);
-      console.log(`Found ${enemies.length} enemies!`);
-      let randomEnemy = BossRoomBot.getEnemy(tickInfo, lastEnemyId);
-      if (!randomEnemy) {
-        randomEnemy = BossRoomBot.nearestEnemy(tickInfo, myPlayer.position);
-      }
-      if (randomEnemy) {
-        lastEnemyId = randomEnemy.id;
-        BossRoomBot.startAbility(ability, randomEnemy.position, randomEnemy.id, actionQueue);
-      } else {
-        lastEnemyId = -1;
-      }
+    const enemies = BossRoomBot.getEnemies(tickInfo);
+    console.log(`Found ${enemies.length} enemies!`);
+    let randomEnemy = BossRoomBot.getEnemy(tickInfo, lastEnemyId);
+    if (!randomEnemy) {
+      randomEnemy = BossRoomBot.nearestEnemy(tickInfo, myPlayer.position);
+    }
+    if (randomEnemy) {
+      lastEnemyId = randomEnemy.id;
+      BossRoomBot.startAbility(ability, randomEnemy.position, randomEnemy.id, actionQueue);
+    } else {
+      lastEnemyId = -1;
+    }
   } else {
-      const allies = BossRoomBot.getAllies(tickInfo);
-      console.log(`Found ${allies.length} allies!`);
-      let randomAlly;
-      if (CharInfo.abilityTargets[charType][abilityIndex] < 0 ){
-        //target self
-        randomAlly = myPlayer;
-      } else {
-        randomAlly = allies[Math.floor(Math.random() * allies.length)];
-      }
-      BossRoomBot.startAbility(ability, randomAlly.position, randomAlly.id, actionQueue);
+    const allies = BossRoomBot.getAllies(tickInfo);
+    console.log(`Found ${allies.length} allies!`);
+    let randomAlly;
+    if (CharInfo.abilityTargets[charType][abilityIndex] < 0 ){
+      //target self
+      randomAlly = myPlayer;
+    } else {
+      randomAlly = allies[Math.floor(Math.random() * allies.length)];
+    }
+    BossRoomBot.startAbility(ability, randomAlly.position, randomAlly.id, actionQueue);
   }
   CURRENT_ABILITY++;
-
-} 
+}
 
 export function getCharacterType() {
   return CharInfo.type[charType];

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ let lastEnemyId = -1;
 
 export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
 
-  console.log(`Running 'runTurn' with playerId: ${playerId}, tickInfo: ${tickInfo}`)
+  console.log(`Running 'runTurn' with playerId: ${playerId}, tickInfo: ${JSON.stringify(tickInfo)}`)
 
   const myPlayer = BossRoomBot.getAlly(tickInfo, playerId);
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class RGValidator {
 
 }
 
-let charType = (Math.random() * 1000000) % 4;
+let charType = Math.round(Math.random() * 1000000) % 4;
 
 export function configureBot() {
   console.log(`Unity bot configureBot function called, charType: ${charType} !`)

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
     } else {
       randomAlly = allies[Math.floor(Math.random() * allies.length)];
     }
-    BossRoomBot.startAbility(ability, randomAlly ? randomAlly.position : null, randomAlly, actionQueue);
+    BossRoomBot.startAbility(ability, randomAlly ? randomAlly.position : null, randomAlly ? randomAlly.id : null, actionQueue);
   }
   CURRENT_ABILITY++;
 }

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
   // Some abilities require an enemy/ally id and position
   const ability = BossRoomBot.abilities[CURRENT_ABILITY % BossRoomBot.abilities.length];
   console.log(`Trying out ability ${ability}`);
-  if (ability % BossRoomBot.abilities.length == 0) {
+  if (CURRENT_ABILITY % BossRoomBot.abilities.length == 0) {
       const enemies = BossRoomBot.getEnemies(tickInfo);
       console.log(`Found ${enemies.length} enemies!`);
       const randomEnemy = enemies[Math.floor(Math.random() * enemies.length)];

--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ const BossRoomBot = {
     console.log(`Using abilility ${ability} on targetId: ${targetId} at position: ${input.xPosition}, ${input.yPosition}, ${input.zPosition}`)
     actionQueue.queue("PerformSkill", input)
   }
-//test
 }
 
 class RGValidator {

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ let charType = Math.round(Math.random() * 1000000) % 4;
 
 export function configureBot(characterType) {
   console.log(`Unity bot configureBot function called, charType: ${charType} - characterType: ${characterType}`)
-  charType = characterType
+  charType = CharInfo.type.indexOf(characterType)
 }
 
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const BossRoomBot = {
     }
     actionQueue.queue("PerformSkill", input)
   }
-
+//test
 }
 
 class RGValidator {

--- a/index.js
+++ b/index.js
@@ -78,8 +78,7 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
 
   //console.log(`Running 'runTurn' with playerId: ${playerId}, tickInfo: ${JSON.stringify(tickInfo)}`)
 
-  // select 2 abilities per tick
-  selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue);
+  // select 1 ability per tick
   selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue);
 }
 

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
   console.log(`Running 'runTurn' with playerId: ${playerId}, tickInfo: ${JSON.stringify(tickInfo)}`)
 
   const myPlayer = BossRoomBot.getAlly(tickInfo, playerId);
+  console.log(`My player is at position: ${JSON.stringify(myPlayer.position)}`)
 
   // Some abilities require an enemy/ally id and position
   const abilities = CharInfo.abilities[charType];

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const CharInfo = {
   type: ["Mage", "Rogue", "Tank", "Archer"],
   abilities: [[0,1], [0,1,2], [0,1], [0,1,2]],
   // teamId
-  abilityTargets: [[1,0], [1,1,0], [1,0], [1,1,1]]
+  abilityTargets: [[1,0], [1,1,-1], [1,-1], [1,1,1]]
 
 }
 
@@ -103,7 +103,13 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
   } else {
       const allies = BossRoomBot.getAllies(tickInfo);
       console.log(`Found ${allies.length} allies!`);
-      const randomAlly = allies[Math.floor(Math.random() * allies.length)];
+      let randomAlly;
+      if (CharInfo.abilityTargets[charType][abilityIndex] < 0 ){
+        //target self
+        randomAlly = myPlayer;
+      } else {
+        randomAlly = allies[Math.floor(Math.random() * allies.length)];
+      }
       BossRoomBot.startAbility(ability, randomAlly.position, randomAlly.id, actionQueue);
   }
   CURRENT_ABILITY++;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const RGBot = {
     return Object.values(tickInfo.gameState).filter(bot => bot.team === team);
   }
 
-}
+} 
 
 const BossRoomBot = {
 

--- a/index.js
+++ b/index.js
@@ -10,11 +10,16 @@ const RGBot = {
 
 const BossRoomBot = {
 
-  abilities: [0, 1, 2],
+  // mage only has 2 abilities, other characterTypes may have more
+  abilities: [0, 1],
 
   getEnemies: (tickInfo) => {
     return RGBot.getEntitiesOnTeam(tickInfo, 1);
   },
+  
+  getAllies: (tickInfo) => {
+    return RGBot.getEntitiesOnTeam(tickInfo, 0);
+  }
 
   startAbility: (ability, position, targetId, actionQueue) => {
     const input = {
@@ -44,15 +49,20 @@ export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
 
   console.log(`Running 'runTurn' with new tickInfo`)
 
-  // Collect some initial information that is needed
-  const enemies = BossRoomBot.getEnemies(tickInfo);
-  console.log(`Found ${enemies.length} enemies!`);
-
-  // Some abilities require an enemy id and position
-  const randomEnemy = enemies[Math.floor(Math.random() * enemies.length)];
+  // Some abilities require an enemy/ally id and position
   const ability = BossRoomBot.abilities[CURRENT_ABILITY % BossRoomBot.abilities.length];
   console.log(`Trying out ability ${ability}`);
-  BossRoomBot.startAbility(ability, randomEnemy.position, randomEnemy.id, actionQueue);
+  if (ability % BossRoomBot.abilities.length == 0) {
+      const enemies = BossRoomBot.getEnemies(tickInfo);
+      console.log(`Found ${enemies.length} enemies!`);
+      const randomEnemy = enemies[Math.floor(Math.random() * enemies.length)];
+      BossRoomBot.startAbility(ability, randomEnemy.position, randomEnemy.id, actionQueue);
+  } else {
+      const allies = BossRoomBot.getAllies(tickInfo);
+      console.log(`Found ${allies.length} allies!`);
+      const randomAlly = allies[Math.floor(Math.random() * allies.length)];
+      BossRoomBot.startAbility(ability, randomAlly.position, randomAlly.id, actionQueue);
+  }
   CURRENT_ABILITY++;
 
 } 

--- a/index.js
+++ b/index.js
@@ -58,8 +58,10 @@ export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
   console.log(`Running 'runTurn' with new tickInfo`)
 
   // Some abilities require an enemy/ally id and position
-  const abilityIndex = CURRENT_ABILITY % CharInfo.abilities[charType].length;
-  const ability = CharInfo.abilities[charType][abilityIndex];
+  const abilities = CharInfo.abilities[charType];
+  console.log(`Considering abilities JSON.stringify(abilities)`);
+  const abilityIndex = CURRENT_ABILITY % abilities.length;
+  const ability = abilities[abilityIndex];
   console.log(`Trying out ability ${ability}`);
   if (CharInfo.abilityTargets[charType][abilityIndex] == 1) {
       const enemies = BossRoomBot.getEnemies(tickInfo);

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const BossRoomBot = {
   },
 
   nearestEnemy: (tickInfo, position) => {
-    return RGBot.getEntitiesOnTeam(tickInfo, 1).toSorted((a,b) => MathFunctions.distanceSq(position, a.position) - MathFunctions.distanceSq(position, b.position));
+    return RGBot.getEntitiesOnTeam(tickInfo, 1).sort((a,b) => MathFunctions.distanceSq(position, a.position) - MathFunctions.distanceSq(position, b.position)).find(() => true);
   },
 
   startAbility: (ability, position, targetId, actionQueue) => {

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ let lastEnemyId = -1;
 
 export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
 
-  console.log(`Running 'runTurn' with new tickInfo`)
+  console.log(`Running 'runTurn' with playerId: ${playerId}, tickInfo: ${tickInfo}`)
 
   const myPlayer = BossRoomBot.getAlly(tickInfo, playerId);
 

--- a/index.js
+++ b/index.js
@@ -43,9 +43,9 @@ const BossRoomBot = {
     const input = {
       skillId: ability,
       targetId: targetId,
-      xPosition: position.x,
-      yPosition: position.y,
-      zPosition: position.z
+      xPosition: position != null ? position.x : null,
+      yPosition: position != null ? position.y : null,
+      zPosition: position != null ? position.z : null
     }
     actionQueue.queue("PerformSkill", input)
   }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 
-
+ 
 const RGBot = {
 
   getEntitiesOnTeam: (tickInfo, team) => {

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ let CURRENT_ABILITY = 0;
 
 export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
 
-  console.log(tickInfo)
+  console.log(`Running 'runTurn' with new tickInfo`)
 
   // Collect some initial information that is needed
   const enemies = BossRoomBot.getEnemies(tickInfo);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const RGBot = {
     return Object.values(tickInfo.gameState).filter(bot => bot.team === team);
   }
 
-} 
+}
 
 const BossRoomBot = {
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const BossRoomBot = {
 
   nearestEnemy: (tickInfo, position) => {
     return RGBot.getEntitiesOnTeam(tickInfo, 1).toSorted((a,b) => MathFunctions.distanceSq(position, a.position) - MathFunctions.distanceSq(position, b.position));
-  }
+  },
 
   startAbility: (ability, position, targetId, actionQueue) => {
     const input = {
@@ -56,9 +56,9 @@ class RGValidator {
 
 }
 
-class MathFunctions {
+const MathFunctions = {
   distanceSq: (position1, position2) => {
-    return Math.pow(position2.x - position1.x, 2) + Math.pow(position2.y - position1.y, 2) + Math.pow(position2.z - position1.z, 2)
+    return Math.pow(position2.x - position1.x, 2) + Math.pow(position2.y - position1.y, 2) + Math.pow(position2.z - position1.z, 2);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ const BossRoomBot = {
       yPosition: position != null ? position.y : null,
       zPosition: position != null ? position.z : null
     }
+    console.log(`Using abilility ${ability} on targetId: ${targetId} at position: ${input.xPosition}, ${input.yPosition}, ${input.zPosition}`)
     actionQueue.queue("PerformSkill", input)
   }
 //test
@@ -84,7 +85,7 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
 
 function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
   const myPlayer = BossRoomBot.getAlly(tickInfo, playerId);
-  console.log(`My player is at position: ${JSON.stringify(myPlayer.position)}`)
+  //console.log(`My player is at position: ${JSON.stringify(myPlayer.position)}`)
 
   // Some abilities require an enemy/ally id and position
   const abilities = CharInfo.abilities[charType];

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const BossRoomBot = {
     }
     actionQueue.queue("PerformSkill", input)
   }
-//test
+
 }
 
 class RGValidator {
@@ -46,8 +46,9 @@ class RGValidator {
 
 let charType = Math.round(Math.random() * 1000000) % 4;
 
-export function configureBot() {
-  console.log(`Unity bot configureBot function called, charType: ${charType} !`)
+export function configureBot(characterType) {
+  console.log(`Unity bot configureBot function called, charType: ${charType} - characterType: ${characterType}`)
+  charType = characterType
 }
 
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ const BossRoomBot = {
     return RGBot.getEntitiesOnTeam(tickInfo, 0);
   },
 
+  getEnemy: (tickInfo, id) => {
+    return RGBot.getEntitiesOnTeam(tickInfo, 1).find(entry => entry.id == id);
+  },
+
   startAbility: (ability, position, targetId, actionQueue) => {
     const input = {
       skillId: ability,
@@ -54,6 +58,8 @@ export function configureBot(characterType) {
 
 let CURRENT_ABILITY = 0;
 
+let lastEnemyId = -1;
+
 export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
 
   console.log(`Running 'runTurn' with new tickInfo`)
@@ -67,8 +73,16 @@ export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
   if (CharInfo.abilityTargets[charType][abilityIndex] == 1) {
       const enemies = BossRoomBot.getEnemies(tickInfo);
       console.log(`Found ${enemies.length} enemies!`);
-      const randomEnemy = enemies[Math.floor(Math.random() * enemies.length)];
-      BossRoomBot.startAbility(ability, randomEnemy.position, randomEnemy.id, actionQueue);
+      let randomEnemy = BossRoomBot.getEnemy(tickInfo, lastEnemyId);
+      if (!randomEnemy) {
+        randomEnemy = enemies[Math.floor(Math.random() * enemies.length)];
+      }
+      if (randomEnemy) {
+        lastEnemyId = randomEnemy.id;
+        BossRoomBot.startAbility(ability, randomEnemy.position, randomEnemy.id, actionQueue);
+      } else {
+        lastEnemyId = -1;
+      }
   } else {
       const allies = BossRoomBot.getAllies(tickInfo);
       console.log(`Found ${allies.length} allies!`);

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
 
   // select 1 ability per tick
   selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue);
-}  
+}
 
 function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
   const myPlayer = BossRoomBot.getAlly(tickInfo, playerId);
@@ -115,7 +115,7 @@ function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
     } else {
       randomAlly = allies[Math.floor(Math.random() * allies.length)];
     }
-    BossRoomBot.startAbility(ability, randomAlly.position, null, actionQueue);
+    BossRoomBot.startAbility(ability, randomAlly ? randomAlly.position : null, randomAlly, actionQueue);
   }
   CURRENT_ABILITY++;
 }

--- a/index.js
+++ b/index.js
@@ -8,10 +8,16 @@ const RGBot = {
 
 }
 
-const BossRoomBot = {
+const CharInfo = {
+  
+  type: ["Mage", "Rogue", "Tank", "Archer"],
+  abilities: [[0,1], [0,1,2], [0,1], [0,1,2]],
+  // teamId
+  abilityTargets: [[1,0], [1,1,0], [1,0], [1,1,1]]
 
-  // mage only has 2 abilities, other characterTypes may have more
-  abilities: [0, 1],
+}
+
+const BossRoomBot = {
 
   getEnemies: (tickInfo) => {
     return RGBot.getEntitiesOnTeam(tickInfo, 1);
@@ -38,8 +44,10 @@ class RGValidator {
 
 }
 
+let charType = Math.random() * 100 % 4;
+
 export function configureBot() {
-  console.log("Unity bot configureBot function called !")
+  console.log(`Unity bot configureBot function called, charType: ${charType} !`)
 }
 
 
@@ -50,9 +58,10 @@ export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
   console.log(`Running 'runTurn' with new tickInfo`)
 
   // Some abilities require an enemy/ally id and position
-  const ability = BossRoomBot.abilities[CURRENT_ABILITY % BossRoomBot.abilities.length];
+  const abilityIndex = CURRENT_ABILITY % CharInfo.abilities[charType].length;
+  const ability = CharInfo.abilities[charType][abilityIndex];
   console.log(`Trying out ability ${ability}`);
-  if (CURRENT_ABILITY % BossRoomBot.abilities.length == 0) {
+  if (CharInfo.abilityTargets[charType][abilityIndex] == 1) {
       const enemies = BossRoomBot.getEnemies(tickInfo);
       console.log(`Found ${enemies.length} enemies!`);
       const randomEnemy = enemies[Math.floor(Math.random() * enemies.length)];
@@ -68,5 +77,5 @@ export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
 } 
 
 export function getCharacterType() {
-  return "Mage";
+  return CharInfo.type[charType];
 }

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
 
   // select 1 ability per tick
   selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue);
-}
+}  
 
 function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
   const myPlayer = BossRoomBot.getAlly(tickInfo, playerId);

--- a/index.js
+++ b/index.js
@@ -111,7 +111,6 @@ function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
     console.log(`Found ${allies.length} allies!`);
     let randomAlly;
     if (targetType == -1 ){
-      //target self
       randomAlly = null;
     } else {
       randomAlly = allies[Math.floor(Math.random() * allies.length)];

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const BossRoomBot = {
   
   getAllies: (tickInfo) => {
     return RGBot.getEntitiesOnTeam(tickInfo, 0);
-  }
+  },
 
   startAbility: (ability, position, targetId, actionQueue) => {
     const input = {

--- a/index.js
+++ b/index.js
@@ -56,3 +56,7 @@ export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
   CURRENT_ABILITY++;
 
 }
+
+export function getCharacterType() {
+  return "Mage";
+}

--- a/index.js
+++ b/index.js
@@ -81,6 +81,9 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
 
   // select 1 ability per tick
   selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue);
+
+
+  //TODO: Add script sensors to the door and button so that a bot can walk to a button if door not open
 }
 
 function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
   BossRoomBot.startAbility(ability, randomEnemy.position, randomEnemy.id, actionQueue);
   CURRENT_ABILITY++;
 
-}
+} 
 
 export function getCharacterType() {
   return "Mage";

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const CharInfo = {
 const BossRoomBot = {
 
   getEnemies: (tickInfo) => {
-    return RGBot.getEntitiesOnTeam(tickInfo, 1);
+    return RGBot.getEntitiesOnTeam(tickInfo, 1).filter(entry => !entry.broken);
   },
   
   getAllies: (tickInfo) => {
@@ -36,7 +36,7 @@ const BossRoomBot = {
   },
 
   nearestEnemy: (tickInfo, position) => {
-    return RGBot.getEntitiesOnTeam(tickInfo, 1).sort((a,b) => MathFunctions.distanceSq(position, a.position) - MathFunctions.distanceSq(position, b.position)).find(() => true);
+    return RGBot.getEntitiesOnTeam(tickInfo, 1).filter(entry => !entry.broken).sort((a,b) => MathFunctions.distanceSq(position, a.position) - MathFunctions.distanceSq(position, b.position)).find(() => true);
   },
 
   startAbility: (ability, position, targetId, actionQueue) => {

--- a/index.js
+++ b/index.js
@@ -31,6 +31,14 @@ const BossRoomBot = {
     return RGBot.getEntitiesOnTeam(tickInfo, 1).find(entry => entry.id == id);
   },
 
+  getAlly: (tickInfo, id) => {
+    return RGBot.getEntitiesOnTeam(tickInfo, 0).find(entry => entry.id == id);
+  },
+
+  nearestEnemy: (tickInfo, position) => {
+    return RGBot.getEntitiesOnTeam(tickInfo, 1).toSorted((a,b) => MathFunctions.distanceSq(position, a.position) - MathFunctions.distanceSq(position, b.position));
+  }
+
   startAbility: (ability, position, targetId, actionQueue) => {
     const input = {
       skillId: ability,
@@ -48,6 +56,12 @@ class RGValidator {
 
 }
 
+class MathFunctions {
+  distanceSq: (position1, position2) => {
+    return Math.pow(position2.x - position1.x, 2) + Math.pow(position2.y - position1.y, 2) + Math.pow(position2.z - position1.z, 2)
+  }
+}
+
 let charType = Math.round(Math.random() * 1000000) % 4;
 
 export function configureBot(characterType) {
@@ -60,9 +74,11 @@ let CURRENT_ABILITY = 0;
 
 let lastEnemyId = -1;
 
-export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
+export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
 
   console.log(`Running 'runTurn' with new tickInfo`)
+
+  const myPlayer = BossRoomBot.getAlly(tickInfo, playerId);
 
   // Some abilities require an enemy/ally id and position
   const abilities = CharInfo.abilities[charType];
@@ -75,7 +91,7 @@ export async function runTurn(tickInfo, mostRecentMatchInfo, actionQueue) {
       console.log(`Found ${enemies.length} enemies!`);
       let randomEnemy = BossRoomBot.getEnemy(tickInfo, lastEnemyId);
       if (!randomEnemy) {
-        randomEnemy = enemies[Math.floor(Math.random() * enemies.length)];
+        randomEnemy = BossRoomBot.nearestEnemy(tickInfo, myPlayer.position);
       }
       if (randomEnemy) {
         lastEnemyId = randomEnemy.id;

--- a/index.js
+++ b/index.js
@@ -92,7 +92,8 @@ function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
   const abilityIndex = CURRENT_ABILITY % abilities.length;
   const ability = abilities[abilityIndex];
   console.log(`Trying out ability ${ability}`);
-  if (CharInfo.abilityTargets[charType][abilityIndex] == 1) {
+  const targetType = CharInfo.abilityTargets[charType][abilityIndex]
+  if ( targetType == 1) {
     const enemies = BossRoomBot.getEnemies(tickInfo);
     console.log(`Found ${enemies.length} enemies!`);
     let randomEnemy = BossRoomBot.getEnemy(tickInfo, lastEnemyId);
@@ -109,7 +110,7 @@ function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
     const allies = BossRoomBot.getAllies(tickInfo);
     console.log(`Found ${allies.length} allies!`);
     let randomAlly;
-    if (CharInfo.abilityTargets[charType][abilityIndex] < 0 ){
+    if (targetType == -1 ){
       //target self
       randomAlly = myPlayer;
     } else {

--- a/index.js
+++ b/index.js
@@ -112,11 +112,11 @@ function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
     let randomAlly;
     if (targetType == -1 ){
       //target self
-      randomAlly = myPlayer;
+      randomAlly = null;
     } else {
       randomAlly = allies[Math.floor(Math.random() * allies.length)];
     }
-    BossRoomBot.startAbility(ability, randomAlly.position, randomAlly.id, actionQueue);
+    BossRoomBot.startAbility(ability, randomAlly.position, null, actionQueue);
   }
   CURRENT_ABILITY++;
 }

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ let lastEnemyId = -1;
 
 export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
 
-  console.log(`Running 'runTurn' with playerId: ${playerId}, tickInfo: ${JSON.stringify(tickInfo)}`)
+  //console.log(`Running 'runTurn' with playerId: ${playerId}, tickInfo: ${JSON.stringify(tickInfo)}`)
 
   // select 2 abilities per tick
   selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue);


### PR DESCRIPTION
- Allows bots to select their character type
- Lets bots know their playerId
- Fixed the security token
- Made an updated version of the UnityTestBot that now randomly selects one of the 4 character types to play as on each run
- Made some QOL improvements to UnityTestBot so that it picks valid actions for each character type and selects reasonable targets instead of fully random
- Added the crystals as valid targets for the bot, including understanding when they are broken
- Addressed an issue where we were binding everything to the network object ids in the state data which wouldn't work for non-network games.
  - This now goes off the transform id and your bot gets notified of what its id is after connecting so you can compute distances from your bot.
- Made some adjustments so that targetless actions work (like the tank shield)
- Reduced the log spam of state on the bot side, but we still need to trim down the unity side spam

Other PRS
 (https://github.com/Regression-Games/RGBossRoom/pull/8)
 (https://github.com/Regression-Games/RegressionGames/pull/294)
