### PR TITLE
[REG-1010] Use instant bots for Unity matches

### DIFF
--- a/abilitybot/index.js
+++ b/abilitybot/index.js
@@ -71,7 +71,7 @@ function selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
       const originalHealth = randomEnemy.health;
       rgValidator.validate(`[${charName}] Damage Given - Offense Ability #` + ability, t + 1000, (newTick) => {
         const enemyState = BossRoomBot.getEnemy(newTick, randomEnemy.id);
-        return enemyState.health < originalHealth;
+        return !enemyState || enemyState.health < originalHealth;
       });
 
     } else {

--- a/abilitybot/index.js
+++ b/abilitybot/index.js
@@ -18,13 +18,17 @@ let rgValidator = new RGValidator();
 
 export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
 
-  // On each state, run through the validations and see if any failed or passed
-  rgValidator.checkValidations(tickInfo);
 
-  // select 1 ability per update
-  selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue);
+  if ("BossRoom" == tickInfo.sceneName) {
 
-  //TODO: Add script sensors to the door and button so that a bot can walk to a button if door not open
+    // On each state, run through the validations and see if any failed or passed
+    rgValidator.checkValidations(tickInfo);
+
+    // select 1 ability per update
+    selectAbility(playerId, tickInfo, mostRecentMatchInfo, actionQueue);
+
+    //TODO: Add script sensors to the door and button so that a bot can walk to a button if door not open
+  }
 }
 
 /**

--- a/coopbot/index.js
+++ b/coopbot/index.js
@@ -17,32 +17,35 @@ export function configureBot(characterType) {
  */
 export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
 
-  // First, get all the information needed to perform the various checks
-  const myState = BossRoomBot.getAlly(tickInfo, playerId);
-  const doorSwitchState = BossRoomBot.getDoorSwitch(tickInfo);
 
-  // If the bot is standing on the switch, do nothing
-  if (doorSwitchState && doorSwitchState.isOn) return;
+  if ("BossRoom" == tickInfo.sceneName) {
 
-  // If the switch is within a range of 30 units from the bot, move onto the switch
-  if (doorSwitchState && MathFunctions.distanceSq(myState.position, doorSwitchState.position) < 30) {
-    BossRoomBot.followObject(doorSwitchState, 0.1, actionQueue);
-    return;
+    // First, get all the information needed to perform the various checks
+    const myState = BossRoomBot.getAlly(tickInfo, playerId);
+    const doorSwitchState = BossRoomBot.getDoorSwitch(tickInfo);
+
+    // If the bot is standing on the switch, do nothing
+    if (doorSwitchState && doorSwitchState.isOn) return;
+
+    // If the switch is within a range of 30 units from the bot, move onto the switch
+    if (doorSwitchState && MathFunctions.distanceSq(myState.position, doorSwitchState.position) < 30) {
+      BossRoomBot.followObject(doorSwitchState, 0.1, actionQueue);
+      return;
+    }
+
+    // If the bot is not near the player, move within range of the player
+    const humanPlayer = BossRoomBot.getHumans(tickInfo)[0];
+    if (humanPlayer && MathFunctions.distanceSq(humanPlayer.position, myState.position) > 7) {
+      BossRoomBot.followObject(humanPlayer, 2, actionQueue);
+      return;
+    }
+
+    // Otherwise, attack nearby enemies, if there is one
+    const nearbyEnemy = BossRoomBot.nearestEnemy(tickInfo, myState.position);
+    if (nearbyEnemy) {
+      BossRoomBot.startAbility(1, nearbyEnemy.position, nearbyEnemy.id, actionQueue);
+    }
   }
-
-  // If the bot is not near the player, move within range of the player
-  const humanPlayer = BossRoomBot.getHumans(tickInfo)[0];
-  if (humanPlayer && MathFunctions.distanceSq(humanPlayer.position, myState.position) > 7) {
-    BossRoomBot.followObject(humanPlayer, 2, actionQueue);
-    return;
-  }
-
-  // Otherwise, attack nearby enemies, if there is one
-  const nearbyEnemy = BossRoomBot.nearestEnemy(tickInfo, myState.position);
-  if (nearbyEnemy) {
-    BossRoomBot.startAbility(1, nearbyEnemy.position, nearbyEnemy.id, actionQueue);
-  }
-
 }
 
 /**

--- a/menubot/index.js
+++ b/menubot/index.js
@@ -3,7 +3,7 @@ import {RGValidator, RGBot} from "../rg";
 
 const abilityBot = import("../abilitybot/index");
 
-let charType = Math.round(Math.random() * 1000000) % 4;
+let charType = 1; // fixed to rogue character
 
 export function configureBot(characterType) {
   console.log(`Unity bot configureBot function called, charType: ${charType} - characterType: ${characterType}`);
@@ -24,6 +24,8 @@ let stateFlags = {
   "Seat7Button":false,
 }
 
+let playedGame = false;
+
 export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue) {
 
   // On each state, run through the validations and see if any failed or passed
@@ -38,46 +40,56 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
   switch (sceneName) {
     case "MainMenu":
 
-      const hostButton = getInteractableButton(tickInfo, "RGHostButton");
-      if (hostButton && stateFlags["StartWithRGButton"] && !stateFlags["RGHostButton"]) {
-        clickButton(hostButton.id, actionQueue);
-        stateFlags["RGHostButton"] = true
-      }
+      if (playedGame) {
+        botComplete = true;
+      } else {
+        const hostButton = getInteractableButton(tickInfo, "RGHostButton");
+        if (hostButton && stateFlags["StartWithRGButton"] && !stateFlags["RGHostButton"]) {
+          clickButton(hostButton.id, actionQueue);
+          stateFlags["RGHostButton"] = true
+        }
 
-      const startButton = getInteractableButton(tickInfo, "StartWithRGButton");
-      if (startButton && stateFlags["SelectProfileButton"] && !stateFlags["StartWithRGButton"]) {
-        clickButton(startButton.id, actionQueue);
-        stateFlags["StartWithRGButton"] = true
-      }
+        const startButton = getInteractableButton(tickInfo, "StartWithRGButton");
+        if (startButton && stateFlags["SelectProfileButton"] && !stateFlags["StartWithRGButton"]) {
+          clickButton(startButton.id, actionQueue);
+          stateFlags["StartWithRGButton"] = true
+        }
 
-      const selectProfileButton = getInteractableButton(tickInfo, "SelectProfileButton");
-      if (selectProfileButton && stateFlags["ProfileMenuButton"] && !stateFlags["SelectProfileButton"]) {
-        clickButton(selectProfileButton.id, actionQueue);
-        stateFlags["SelectProfileButton"] = true
-      }
+        const selectProfileButton = getInteractableButton(tickInfo, "SelectProfileButton");
+        if (selectProfileButton && stateFlags["ProfileMenuButton"] && !stateFlags["SelectProfileButton"]) {
+          clickButton(selectProfileButton.id, actionQueue);
+          stateFlags["SelectProfileButton"] = true
+        }
 
-      const profileMenuButton = getInteractableButton(tickInfo, "ProfileMenuButton");
-      if (profileMenuButton && !stateFlags["ProfileMenuButton"]) {
-        clickButton(profileMenuButton.id, actionQueue);
-        stateFlags["ProfileMenuButton"] = true
+        const profileMenuButton = getInteractableButton(tickInfo, "ProfileMenuButton");
+        if (profileMenuButton && !stateFlags["ProfileMenuButton"]) {
+          clickButton(profileMenuButton.id, actionQueue);
+          stateFlags["ProfileMenuButton"] = true
+        }
       }
 
       break;
     case "CharSelect":
-      const readyButton = getInteractableButton(tickInfo, "ReadyButton");
-      if (readyButton && stateFlags["Seat7Button"] && !stateFlags["ReadyButton"]) {
-        clickButton(readyButton.id, actionQueue);
-        stateFlags["ReadyButton"] = true
-      }
+      if (playedGame) {
+        botComplete = true;
+      } else {
+        const readyButton = getInteractableButton(tickInfo, "ReadyButton");
+        if (readyButton && stateFlags["Seat7Button"] && !stateFlags["ReadyButton"]) {
+          clickButton(readyButton.id, actionQueue);
+          stateFlags["ReadyButton"] = true
+        }
 
-      const seat7Button = getInteractableButton(tickInfo, "Seat7Button");
-      if (seat7Button && !stateFlags["Seat7Button"]) {
-        clickButton(seat7Button.id, actionQueue);
-        stateFlags["Seat7Button"] = true
+        const seat7Button = getInteractableButton(tickInfo, "Seat7Button");
+        if (seat7Button && !stateFlags["Seat7Button"]) {
+          clickButton(seat7Button.id, actionQueue);
+          stateFlags["Seat7Button"] = true
+        }
       }
 
       break;
     case "BossRoom":
+      playedGame = true;
+
       const GameHUDStartButton = getInteractableButton(tickInfo, "GameHUDStartButton");
       if (GameHUDStartButton && stateFlags["CheatsCancelButton"] && !stateFlags["GameHUDStartButton"]) {
         clickButton(GameHUDStartButton.id, actionQueue);
@@ -95,6 +107,7 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
         console.log(`Calling abilityBot.runTurn ...`)
         await abilityBot.runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue)
       }
+
       break;
     case "PostGame":
     default:

--- a/menubot/index.js
+++ b/menubot/index.js
@@ -89,13 +89,13 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
         clickButton(CheatsCancelButton.id, actionQueue);
         stateFlags["CheatsCancelButton"] = true
       }
-      break;
 
       if( stateFlags["CheatsCancelButton"] && stateFlags["GameHUDStartButton"]) {
         // run the ability bot
         console.log(`Calling abilityBot.runTurn ...`)
         await abilityBot.runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue)
       }
+      break;
     case "PostGame":
     default:
       // teardown myself

--- a/menubot/index.js
+++ b/menubot/index.js
@@ -90,20 +90,27 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
     case "BossRoom":
       playedGame = true;
 
+      const GameHUDStartButton = getInteractableButton(tickInfo, "GameHUDStartButton");
+      const CheatsCancelButton = getInteractableButton(tickInfo, "CheatsCancelButton");
+      if (!GameHUDStartButton && !CheatsCancelButton) {
+        stateFlags["CheatsCancelButton"] = true
+        stateFlags["GameHUDStartButton"] = true
+      }
 
       if( stateFlags["CheatsCancelButton"] && stateFlags["GameHUDStartButton"]) {
         // run the ability bot
         console.log(`Calling abilityBot.runTurn ...`)
+        console.log(`${JSON.stringify(abilityBot)}`)
         await abilityBot.runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue)
       }
 
-      const GameHUDStartButton = getInteractableButton(tickInfo, "GameHUDStartButton");
+
       if (GameHUDStartButton && stateFlags["CheatsCancelButton"] && !stateFlags["GameHUDStartButton"]) {
         clickButton(GameHUDStartButton.id, actionQueue);
         stateFlags["GameHUDStartButton"] = true
       }
 
-      const CheatsCancelButton = getInteractableButton(tickInfo, "CheatsCancelButton");
+
       if (CheatsCancelButton && !stateFlags["CheatsCancelButton"]) {
         clickButton(CheatsCancelButton.id, actionQueue);
         stateFlags["CheatsCancelButton"] = true

--- a/menubot/index.js
+++ b/menubot/index.js
@@ -1,8 +1,6 @@
 import {BossRoomBot, CharInfo} from "../bossroom";
 import {RGValidator, RGBot} from "../rg";
 
-const abilityBot = import("../abilitybot/index");
-
 let charType = 1; // fixed to rogue character
 
 export function configureBot(characterType) {
@@ -94,22 +92,13 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
       if (GameHUDStartButton && stateFlags["CheatsCancelButton"] && !stateFlags["GameHUDStartButton"]) {
         clickButton(GameHUDStartButton.id, actionQueue);
         stateFlags["GameHUDStartButton"] = true
-      } else {
-        stateFlags["GameHUDStartButton"] = true
       }
 
       const CheatsCancelButton = getInteractableButton(tickInfo, "CheatsCancelButton");
       if (CheatsCancelButton && !stateFlags["CheatsCancelButton"]) {
         clickButton(CheatsCancelButton.id, actionQueue);
         stateFlags["CheatsCancelButton"] = true
-      } else {
-        stateFlags["CheatsCancelButton"] = true
       }
-
-      // run the ability bot
-      console.log(`Calling abilityBot.runTurn ...`)
-      console.log(`${JSON.stringify(abilityBot)}`)
-      await abilityBot.runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue)
 
       break;
     case "PostGame":

--- a/menubot/index.js
+++ b/menubot/index.js
@@ -1,6 +1,8 @@
 import {BossRoomBot, CharInfo} from "../bossroom";
 import {RGValidator, RGBot} from "../rg";
 
+const abilityBot = await import("../abilitybot/index");
+
 let charType = Math.round(Math.random() * 1000000) % 4;
 
 export function configureBot(characterType) {
@@ -75,9 +77,28 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
       }
 
       break;
+    case "BossRoom":
+      const GameHUDStartButton = getInteractableButton(tickInfo, "GameHUDStartButton");
+      if (GameHUDStartButton && stateFlags["CheatsCancelButton"] && !stateFlags["GameHUDStartButton"]) {
+        clickButton(GameHUDStartButton.id, actionQueue);
+        stateFlags["GameHUDStartButton"] = true
+      }
+
+      const CheatsCancelButton = getInteractableButton(tickInfo, "CheatsCancelButton");
+      if (CheatsCancelButton && !stateFlags["CheatsCancelButton"]) {
+        clickButton(CheatsCancelButton.id, actionQueue);
+        stateFlags["CheatsCancelButton"] = true
+      }
+      break;
+
+      if( stateFlags["CheatsCancelButton"] && stateFlags["GameHUDStartButton"]) {
+        // run the ability bot
+        await abilityBot.runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue)
+      }
+    case "PostGame":
     default:
       // teardown myself
-      console.log(`Game started, bot is Complete`)
+      console.log(`Game ended, bot is Complete`)
       botComplete = true;
       break;
   }

--- a/menubot/index.js
+++ b/menubot/index.js
@@ -93,6 +93,7 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
 
       if( stateFlags["CheatsCancelButton"] && stateFlags["GameHUDStartButton"]) {
         // run the ability bot
+        console.log(`Calling abilityBot.runTurn ...`)
         await abilityBot.runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue)
       }
     case "PostGame":

--- a/menubot/index.js
+++ b/menubot/index.js
@@ -1,7 +1,7 @@
 import {BossRoomBot, CharInfo} from "../bossroom";
 import {RGValidator, RGBot} from "../rg";
 
-const abilityBot = await import("../abilitybot/index");
+const abilityBot = import("../abilitybot/index");
 
 let charType = Math.round(Math.random() * 1000000) % 4;
 

--- a/menubot/index.js
+++ b/menubot/index.js
@@ -1,7 +1,7 @@
 import {BossRoomBot, CharInfo} from "../bossroom";
 import {RGValidator, RGBot} from "../rg";
 
-const abilityBot = import("../abilitybot");
+const abilityBot = import("../abilitybot/index");
 
 let charType = 1; // fixed to rogue character
 
@@ -91,30 +91,25 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
       playedGame = true;
 
       const GameHUDStartButton = getInteractableButton(tickInfo, "GameHUDStartButton");
-      const CheatsCancelButton = getInteractableButton(tickInfo, "CheatsCancelButton");
-      if (!GameHUDStartButton && !CheatsCancelButton) {
-        stateFlags["CheatsCancelButton"] = true
-        stateFlags["GameHUDStartButton"] = true
-      }
-
-      if( stateFlags["CheatsCancelButton"] && stateFlags["GameHUDStartButton"]) {
-        // run the ability bot
-        console.log(`Calling abilityBot.runTurn ...`)
-        console.log(`${JSON.stringify(abilityBot)}`)
-        await abilityBot.runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue)
-      }
-
-
       if (GameHUDStartButton && stateFlags["CheatsCancelButton"] && !stateFlags["GameHUDStartButton"]) {
         clickButton(GameHUDStartButton.id, actionQueue);
         stateFlags["GameHUDStartButton"] = true
+      } else {
+        stateFlags["GameHUDStartButton"] = true
       }
 
-
+      const CheatsCancelButton = getInteractableButton(tickInfo, "CheatsCancelButton");
       if (CheatsCancelButton && !stateFlags["CheatsCancelButton"]) {
         clickButton(CheatsCancelButton.id, actionQueue);
         stateFlags["CheatsCancelButton"] = true
+      } else {
+        stateFlags["CheatsCancelButton"] = true
       }
+
+      // run the ability bot
+      console.log(`Calling abilityBot.runTurn ...`)
+      console.log(`${JSON.stringify(abilityBot)}`)
+      await abilityBot.runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue)
 
       break;
     case "PostGame":

--- a/menubot/index.js
+++ b/menubot/index.js
@@ -33,7 +33,7 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
   const sceneName = tickInfo.sceneName;
 
   // too spammy but good for debugging
-  console.log(`Processing tickInfo: ${JSON.stringify(tickInfo)}`)
+  //console.log(`Processing tickInfo: ${JSON.stringify(tickInfo)}`)
 
   switch (sceneName) {
     case "MainMenu":

--- a/menubot/index.js
+++ b/menubot/index.js
@@ -90,6 +90,13 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
     case "BossRoom":
       playedGame = true;
 
+
+      if( stateFlags["CheatsCancelButton"] && stateFlags["GameHUDStartButton"]) {
+        // run the ability bot
+        console.log(`Calling abilityBot.runTurn ...`)
+        await abilityBot.runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue)
+      }
+
       const GameHUDStartButton = getInteractableButton(tickInfo, "GameHUDStartButton");
       if (GameHUDStartButton && stateFlags["CheatsCancelButton"] && !stateFlags["GameHUDStartButton"]) {
         clickButton(GameHUDStartButton.id, actionQueue);
@@ -100,12 +107,6 @@ export async function runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQue
       if (CheatsCancelButton && !stateFlags["CheatsCancelButton"]) {
         clickButton(CheatsCancelButton.id, actionQueue);
         stateFlags["CheatsCancelButton"] = true
-      }
-
-      if( stateFlags["CheatsCancelButton"] && stateFlags["GameHUDStartButton"]) {
-        // run the ability bot
-        console.log(`Calling abilityBot.runTurn ...`)
-        await abilityBot.runTurn(playerId, tickInfo, mostRecentMatchInfo, actionQueue)
       }
 
       break;

--- a/menubot/index.js
+++ b/menubot/index.js
@@ -1,7 +1,7 @@
 import {BossRoomBot, CharInfo} from "../bossroom";
 import {RGValidator, RGBot} from "../rg";
 
-const abilityBot = import("../abilitybot/index");
+const abilityBot = import("../abilitybot");
 
 let charType = 1; // fixed to rogue character
 


### PR DESCRIPTION
- Fixes a validation bug in ability bot where it would sometimes `undefined` and crash
- Updates menu bot to better end itself once it detects that it made it into a game
- Updates ability and coop bot to only process runTurn on scene `BossRoom` to eliminate a bunch of error spam in the logs
- Related PRS (https://github.com/Regression-Games/RGBossRoom/pull/17) (https://github.com/Regression-Games/RegressionGames/pull/307)