### PR TITLE
[REG-1116] Catch and log invalid charType scenarios in abilityBot

### DIFF
--- a/abilitybot/index.js
+++ b/abilitybot/index.js
@@ -38,7 +38,7 @@ export async function processTick(rg) {
 async function selectAbility(rg) {
 
   // Select an ability
-  if (charType>=0 && charType < CharInfo.abilities.length) {
+  if (charType >= 0 && charType < CharInfo.abilities.length) {
     const abilities = CharInfo.abilities[charType];
     if (abilities) {
       const abilityIndex = CURRENT_ABILITY % abilities.length;


### PR DESCRIPTION
- Wasn't ever able to recreate the issue with the invalid abilities.  I'm surprised it could even fail on that line as the charType being an invalid index or undefined/null would cause it to fail on the prior line trying to do the array lookup to find the abilities array.  
  - Either way... This now has belt/suspenders error checking and logging to prevent failure and help diagnose root cause if the conditions that caused this error happen again.
  - Also sets a default value for charType and adds range checks to try to avoid a potential null/undefined case that may have been the root cause here