### PR TITLE
[REG-1050] Add menu and ability combined bot 

### DIFF
--- a/abilitybot/index.js
+++ b/abilitybot/index.js
@@ -44,7 +44,7 @@ async function selectAbility(rg) {
       const abilityIndex = CURRENT_ABILITY % abilities.length;
       const ability = abilities[abilityIndex];
 
-      if (!rg.entityHasAttribute(rg.getBot(), ["isOnCooldown", `ability${ability + 1}Available`], true)) {
+      if (!rg.entityHasAttribute(rg.getBot(), ["isOnCooldown", `ability${ability + 1}Available`], true, false)) {
         return;
       }
 
@@ -61,7 +61,7 @@ async function selectAbility(rg) {
           // If there was no recent enemy id, or if it's no longer available in the state then find the nearest enemy instead
           currentTarget = await rg.findNearestEntity(null, null, (entity) => {
             return entity.team === 1 && !entity.broken
-          })
+          }, false)
           if (!currentTarget) {
             lastEnemyId = -1;
             return;
@@ -72,7 +72,7 @@ async function selectAbility(rg) {
         // Otherwise, this ability requires an ally - select the closest one
         currentTarget = await rg.findNearestEntity(null, null, (entity) => {
           return entity.team === 0
-        });
+        }, false);
         if (!currentTarget) {
           return;
         }

--- a/menuAndAbilityBot/index.js
+++ b/menuAndAbilityBot/index.js
@@ -2,6 +2,10 @@ import { CharInfo } from "../bossroom";
 
 let rg = null;
 
+let CURRENT_ABILITY = 0;
+let lastEnemyId = -1;
+let charType = -1;
+
 export function configureBot(rg) {
   rg.isSpawnable = false;
   rg.lifecycle = "PERSISTENT";
@@ -23,6 +27,16 @@ let stateFlags = {
 let playedGame = false;
 
 export async function processTick(rg) {
+
+  const characterType = rg.characterConfig.characterType;
+  if (characterType) {
+    const newCharType = CharInfo.type.indexOf(characterType);
+    if (charType != newCharType) {
+      charType = newCharType;
+      console.log(`Character type has been set: ${characterType}`);
+    }
+    // do not log if already the same.. should always be the rogue for this bot
+  }
 
   switch (rg.getState().sceneName) {
     case "MainMenu":
@@ -90,8 +104,7 @@ export async function processTick(rg) {
       }
 
       if (stateFlags["CheatsCancelButton"] && stateFlags["GameHUDStartButton"]) {
-        // teardown myself
-        rg.complete()
+        await selectAbility(rg);
       }
 
       break;
@@ -110,4 +123,70 @@ async function getInteractableButton(rg, buttonName) {
     return button;
   }
   return null;
+}
+
+/**
+ * Selects an ability for this character, and queues that action.
+ * This is similar to the code in abilityBot, but separate to avoid having
+ * to maintain the 2 different bot samples' compatibility.
+ */
+async function selectAbility(rg) {
+
+  // Select an ability
+  if (charType >= 0 && charType < CharInfo.abilities.length) {
+    const abilities = CharInfo.abilities[charType];
+    if (abilities) {
+      const abilityIndex = CURRENT_ABILITY % abilities.length;
+      const ability = abilities[abilityIndex];
+
+      if (!rg.entityHasAttribute(rg.getBot(), ["isOnCooldown", `ability${ability + 1}Available`], true, false)) {
+        return;
+      }
+
+      const targetType = CharInfo.abilityTargets[charType][abilityIndex]
+      let currentTarget;
+
+      if (targetType === -1) {
+        currentTarget = null;
+      } else if (targetType === 1) {
+        // The ability requires an enemy.
+
+        currentTarget = await rg.getState(lastEnemyId);
+        if (!currentTarget) {
+          // If there was no recent enemy id, or if it's no longer available in the state then find the nearest enemy instead
+          currentTarget = await rg.findNearestEntity(null, null, (entity) => {
+            return entity.team === 1 && !entity.broken
+          }, false)
+          if (!currentTarget) {
+            lastEnemyId = -1;
+            return;
+          }
+          lastEnemyId = currentTarget.id;
+        }
+      } else {
+        // Otherwise, this ability requires an ally - select the closest one
+        currentTarget = await rg.findNearestEntity(null, null, (entity) => {
+          return entity.team === 0
+        }, false);
+        if (!currentTarget) {
+          return;
+        }
+      }
+
+      rg.performAction("PerformSkill", {
+        skillId: ability,
+        targetId: currentTarget?.id,
+        xPosition: currentTarget?.position?.x,
+        yPosition: currentTarget?.position?.y,
+        zPosition: currentTarget?.position?.z
+      });
+
+      CURRENT_ABILITY++;
+    } else {
+      console.warn(`Invalid abilities for charType index: ${charType}`)
+    }
+  } else {
+    console.warn(`Invalid charType index: ${charType}`)
+  }
+
 }

--- a/menuAndAbilityBot/package.json
+++ b/menuAndAbilityBot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rg-unity-bossroom-menu",
   "version": "1.0.0",
-  "description": "PlayTest bot that navigates from the main menu to the dungeon.",
+  "description": "PlayTest bot that navigates from the main menu to the dungeon and then controls the human player character.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/menuAndAbilityBot/package.json
+++ b/menuAndAbilityBot/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "rg-unity-bossroom-menu",
+  "version": "1.0.0",
+  "description": "PlayTest bot that navigates from the main menu to the dungeon.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Regression Games, Inc",
+  "license": "ISC",
+  "dependencies": {
+    "@types/node": "18.0.6",
+    "node-fetch": "3.3.0",
+    "rg-match-info": "1.1.0"
+  }
+}


### PR DESCRIPTION
- Adds a bot that goes through the menus and then also starts playing
- Updates the base ability bot without validations to turn off validations on actions
- Fixes the existing menuBot to properly end itself once it clears the overlays, instead of waiting for end of match postGame